### PR TITLE
Add category from VS Code command to the label of Theia command

### DIFF
--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
@@ -30,7 +30,14 @@ export const doInitialization: BackendInitializationFn = (apiFactory: PluginAPIF
     const contributes: any = plugin.rawModel.contributes;
     if (contributes && contributes.commands) {
         contributes.commands.forEach((commandItem: any) => {
-            vscode.commands.registerCommand({ id: commandItem.command, label: commandItem.title });
+            if (typeof commandItem.category !== 'undefined' && commandItem.category) {
+                vscode.commands.registerCommand({ id: commandItem.command,
+                    label: commandItem.title });
+            } else {
+                vscode.commands.registerCommand({
+                    id: commandItem.command,
+                    label: commandItem.category + ': ' + commandItem.title });
+            }
         });
     }
 

--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
@@ -30,14 +30,13 @@ export const doInitialization: BackendInitializationFn = (apiFactory: PluginAPIF
     const contributes: any = plugin.rawModel.contributes;
     if (contributes && contributes.commands) {
         contributes.commands.forEach((commandItem: any) => {
-            if (commandItem.category) { // if VS Code command has category we will add it before title, so labbel will looks like 'category: title'
-                vscode.commands.registerCommand({ id: commandItem.command,
-                    label: commandItem.category + ': ' + commandItem.title });
+            let commandLabel: any;
+            if (commandItem.category) { // if VS Code command has category we will add it before title, so label will looks like 'category: title'
+                commandLabel = commandItem.category + ': ' + commandItem.title;
             } else {
-                vscode.commands.registerCommand({
-                    id: commandItem.command,
-                    label: commandItem.title });
+                commandLabel = commandItem.title;
             }
+            vscode.commands.registerCommand({id: commandItem.command, label: commandLabel });
         });
     }
 

--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
@@ -30,13 +30,13 @@ export const doInitialization: BackendInitializationFn = (apiFactory: PluginAPIF
     const contributes: any = plugin.rawModel.contributes;
     if (contributes && contributes.commands) {
         contributes.commands.forEach((commandItem: any) => {
-            if (typeof commandItem.category !== 'undefined' && commandItem.category) {
+            if (commandItem.category) { // if VS Code command has category we will add it before title, so labbel will looks like 'category: title'
                 vscode.commands.registerCommand({ id: commandItem.command,
-                    label: commandItem.title });
+                    label: commandItem.category + ': ' + commandItem.title });
             } else {
                 vscode.commands.registerCommand({
                     id: commandItem.command,
-                    label: commandItem.category + ': ' + commandItem.title });
+                    label: commandItem.title });
             }
         });
     }


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfonov@redhat.com>
If VS Code Command will have categories field like this:
```
{
  "command": "extension.helmVersion",
  "title": "Version (Client)",
  "description": "Get the version of the local Helm client.",
  "category": "Helm"
} 
```
we will add categories to the Theia commands label field as prefix:
`command.label = "Helm: Version (Client)" `

Without categories:
![command-without-category](https://user-images.githubusercontent.com/1636592/45302693-a4006080-b51c-11e8-8a1d-f018e082d6c8.gif)
With categories:
![commna-with-categories](https://user-images.githubusercontent.com/1636592/45302715-b11d4f80-b51c-11e8-8508-2c720df4671d.gif)


<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
